### PR TITLE
allow additional dependencies

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -70,13 +70,21 @@ export default function(cb) {
       propStack.push(new StackEntry(this));
       let result = cb.call(this);
       let entry = propStack.pop();
-      computed.property(...entry.dependentKeys);
+      let meta = computed._meta || {};
+      let staticDependentKeys = meta.__staticDependencies__ || [];
+      let dependentKeys = [...entry.dependentKeys, ...staticDependentKeys];
+      computed.property(...dependentKeys);
       return result;
     } finally {
       Ember.get = originalGet;
       Ember.Object.prototype.get = originalBoundGet;
     }
   });
+
+  computed.depend = function(...keys) {
+    this.meta({ __staticDependencies__: keys });
+    return this;
+  };
 
   return computed;
 }

--- a/tests/unit/auto-computed-test.js
+++ b/tests/unit/auto-computed-test.js
@@ -316,4 +316,21 @@ describe('Unit | auto-computed', function() {
       expect(obj.get('d')).to.equal(1);
     });
   });
+
+  it('allows defining extra dependencies that can not be tracked automatically', function() {
+    let obj = Ember.Object.extend({
+      i18n: {
+        t(key) {
+          return `translation for ${key}`;
+        }
+      },
+
+      translation: computed(function() {
+        return this.get('i18n').t('translationKey');
+      }).depend('i18n.locale')
+    }).create();
+
+    obj.get('translation');
+    expect(obj['translation']._dependentKeys).to.deep.equal(['i18n', 'i18n.locale']);
+  });
 });


### PR DESCRIPTION
This allows specifying additional dependencies that cannot be tracked automatically like `i18n.locale` where the CP function would only `this.get('i18n')` so the actual dependent key could not be automatically inferred.